### PR TITLE
Better default when no path given

### DIFF
--- a/src/hubot-brain-file.coffee
+++ b/src/hubot-brain-file.coffee
@@ -17,7 +17,7 @@ fs   = require 'fs'
 path = require 'path'
 
 module.exports = (robot) ->
-  brainPath = process.env.FILE_BRAIN_PATH or '/var/hubot'
+  brainPath = process.env.FILE_BRAIN_PATH or process.cwd()
   brainPath = path.join brainPath, 'brain-dump.json'
   try
     data = fs.readFileSync brainPath, 'utf-8'


### PR DESCRIPTION
This is a more cross-platform-friendly way of providing a default location, and it's also handy for testing on a local machine.